### PR TITLE
fix: exclude floating windows from resizing logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,4 @@ Distributed under the MIT License. See LICENSE for more information.
 [issues-shield]: https://img.shields.io/github/issues/mboyov/pane-resizer.nvim.svg?style=for-the-badge
 [issues-url]: https://github.com/mboyov/pane-resizer.nvim/issues
 [license-shield]: https://img.shields.io/github/license/mboyov/pane-resizer.nvim.svg?style=for-the-badge
-[license-url]: https://github.com/mboyov/pane-resizer.nvim/blob/main/LICENSE.txt
+[license-url]: https://github.com/mboyov/pane-resizer.nvim/blob/main/LICENSE

--- a/lua/pane_resizer/resize.lua
+++ b/lua/pane_resizer/resize.lua
@@ -10,6 +10,12 @@ local M = {}
 -- Main function to resize only the focused window, enforcing fixed width for NvimTree
 function M.resize_focused_pane()
 	local current_win = api.nvim_get_current_win()
+
+	-- Skip resizing for floating windows
+	if utils.should_exclude_window(current_win) then
+		return
+	end
+
 	local total_width = api.nvim_get_option("columns")
 	local nvimtree_win = nil
 


### PR DESCRIPTION
- Updated `resize_focused_pane` to skip resizing for all floating windows
- Utilized `should_exclude_window` function to identify and ignore floating windows
- Ensured NvimTree retains fixed width without affecting floating windows, including terminal

This fix improves window handling by preventing unintended resizing of floating windows.